### PR TITLE
Add Dump to Response & Request, make Context.Clone copy bodies

### DIFF
--- a/_examples/basic/basic.go
+++ b/_examples/basic/basic.go
@@ -22,6 +22,15 @@ func main() {
 	// Set a new header field
 	req.SetHeader("Client", "gentleman")
 
+	// Get the wire representation of the request
+	b, err := req.Dump(true)
+	if err != nil {
+		fmt.Printf("Dump error: %s\n", err)
+		return
+	}
+	// dump the whole request as its HTTP/1.x wire representation
+	fmt.Printf("Request HTTP/1.x wire representation:\n%s\n", string(b))
+
 	// Perform the request
 	res, err := req.Send()
 	if err != nil {
@@ -33,6 +42,15 @@ func main() {
 		return
 	}
 
-	// Reads the whole body and returns it as string
-	fmt.Printf("Body: %s", res.String())
+	b, err = res.Dump(true)
+	if err != nil {
+		fmt.Printf("Dump error: %s\n", err)
+		return
+	}
+	// dump the whole response as its HTTP/1.x wire representation
+	fmt.Printf("Response HTTP/1.x wire representation:\n%s\n", string(b))
+
+	// Reads the whole request and returns it as string
+	fmt.Printf("Response: %s\n", res.String())
+
 }

--- a/_examples/basic/basic.go
+++ b/_examples/basic/basic.go
@@ -50,7 +50,7 @@ func main() {
 	// dump the whole response as its HTTP/1.x wire representation
 	fmt.Printf("Response HTTP/1.x wire representation:\n%s\n", string(b))
 
-	// Reads the whole request and returns it as string
+	// Reads the whole response body and returns it as string
 	fmt.Printf("Response: %s\n", res.String())
 
 }

--- a/request_test.go
+++ b/request_test.go
@@ -535,6 +535,17 @@ func TestRequestClone(t *testing.T) {
 	utils.Equal(t, len(req2.Middleware.GetStack()), 1)
 }
 
+func TestRequestDump(t *testing.T) {
+	req := NewRequest()
+	req.BodyString("foo bar")
+	b, err := req.Dump(true)
+	utils.Equal(t, err, nil)
+	utils.Equal(t, b, []byte{71, 69, 84, 32, 47, 32, 72, 84, 84, 80, 47, 49, 46, 49,
+		13, 10, 85, 115, 101, 114, 45, 65, 103, 101, 110, 116, 58, 32, 103, 101, 110,
+		116, 108, 101, 109, 97, 110, 47, 50, 46, 48, 46, 51, 13, 10, 13, 10, 102, 111,
+		111, 32, 98, 97, 114})
+}
+
 func BenchmarkSimpleRequestGet(b *testing.B) {
 	ts := createEchoServer()
 	defer ts.Close()

--- a/response.go
+++ b/response.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"io"
 	"net/http"
+	"net/http/httputil"
 	"os"
 
 	"github.com/lytics/gentleman/context"
@@ -233,4 +234,29 @@ func isChunkedResponse(res *http.Response) bool {
 		}
 	}
 	return false
+}
+
+// Clone creates a new side-effects free response based on the current one.
+func (r *Response) Clone() *Response {
+	ctx := r.Context.Clone()
+	resp, err := buildResponse(ctx)
+	if err != nil {
+		return nil
+	}
+	return resp
+}
+
+// Dump returns the given response in its HTTP/1.x wire
+// representation. The response is Cloned, middlewares set to run before
+// response and dial are run on the clone. The resulting response is
+// passed to httputils.DumpResponse for the HTTP1.x wire representation.
+//
+// If body is true, Dump also returns the body. If Dump returns an error,
+// the state of req is undefined.
+//
+// The documentation for httputils.DumpResponse details the returned
+// representation
+func (r *Response) Dump(body bool) ([]byte, error) {
+	tmp := r.Clone()
+	return httputil.DumpResponse(tmp.RawResponse, body)
 }

--- a/response.go
+++ b/response.go
@@ -246,10 +246,9 @@ func (r *Response) Clone() *Response {
 	return resp
 }
 
-// Dump returns the given response in its HTTP/1.x wire
-// representation. The response is Cloned, middlewares set to run before
-// response and dial are run on the clone. The resulting response is
-// passed to httputils.DumpResponse for the HTTP1.x wire representation.
+// Dump returns the given response in its HTTP/1.x wire representation.
+// The response is Cloned and the clone is passed to httputils.DumpResponse
+// for the HTTP1.x wire representation.
 //
 // If body is true, Dump also returns the body. If Dump returns an error,
 // the state of req is undefined.


### PR DESCRIPTION
Closes: #1
Dump method added to Request and Response. It returns the HTTP/1.x wire representation of the request/response using httputil.RequestDump and httputil.RepsonseDump respectively.  Copies the request/response before dumping to preserve the original.

Clone method added to Response. responses can be cloned like requests.

Context.Clone now copies request and response bodies. Previously if a request or response was cloned, the original and clone shared one body, so if the original's body was read the clone's was also drained. now they are duplicated by reading the original body into a buffer and  creating two NopClosers reading from that buffer and a copy of that buffer.

Added Request.Dump and Response.Dump to the basic example